### PR TITLE
Remove model_dat from examples

### DIFF
--- a/causing/__init__.py
+++ b/causing/__init__.py
@@ -1,25 +1,4 @@
 # -*- coding: utf-8 -*-
 """causing - causal interpretation using graphs."""
 
-from causing.utils import create_model, print_output
-from causing.estimate import estimate_models
-from causing.indiv import create_indiv
-from causing.graph import create_json_graphs
-
-
-def analyze(model_raw_dat, estimate=True):
-    model_dat = create_model(model_raw_dat)
-    if estimate:
-        estimate_dat = estimate_models(model_dat)
-    else:
-        estimate_dat = None
-    indiv_dat = create_indiv(model_dat)
-
-    graphs = create_json_graphs(model_dat, estimate_dat, indiv_dat)
-    ret_value = {
-        "model_dat": model_dat,
-        "indiv_dat": indiv_dat,
-        "graph_dat": graphs,
-        "estimate_dat": estimate_dat,
-    }
-    return ret_value
+# TODO: import public API here

--- a/causing/examples/__main__.py
+++ b/causing/examples/__main__.py
@@ -27,18 +27,37 @@ except AttributeError:
 show_nr_indiv = 3
 
 # Do all calculations
-model_raw_dat, estimate_input = model_function()
-model_dat = utils.create_model(model_raw_dat)
-m = model_dat["m"]
-xdat = model_dat["xdat"]
-xmean = model_dat["xdat"].mean(axis=1)
-mean_theo = m.theo(xmean)
-indiv_theos = utils.make_individual_theos(
-    m,
-    model_dat["xdat"],
-    model_dat["show_nr_indiv"],
-)
+m, xdat, ymdat, estimate_input = model_function()
+mean_theo = m.theo(xdat.mean(axis=1))
+indiv_theos = utils.make_individual_theos(m, xdat, show_nr_indiv)
 indiv_dat = create_indiv(m, xdat, indiv_theos, show_nr_indiv)
+model_dat = {  # TODO: completely remove model_dat
+    # from Model class
+    "m": m,
+    "ndim": m.ndim,
+    "mdim": m.mdim,
+    "pdim": len(m.ymvars),
+    "qxdim": m.qxdim,
+    "qydim": m.qydim,
+    "qdim": m.qdim,
+    "idx": m.idx,
+    "idy": m.idy,
+    "edx": m.edx,
+    "edy": m.edy,
+    "fdx": m.fdx,
+    "fdy": m.fdy,
+    "model": m.compute,
+    "mx_lam": m.m_pair[0],
+    "my_lam": m.m_pair[1],
+    "xvars": m.xvars,
+    "yvars": m.yvars,
+    "final_var": m.final_var,
+    "ymvars": m.ymvars,
+    # other
+    "xdat": xdat,
+    "tau": xdat.shape[1],
+    "show_nr_indiv": show_nr_indiv,
+}
 model_dat.update(mean_theo)
 model_dat.update(indiv_theos)
 estimate_dat = estimate.estimate_models(model_dat, estimate_input)

--- a/causing/examples/__main__.py
+++ b/causing/examples/__main__.py
@@ -3,10 +3,11 @@ from pathlib import Path
 import json
 import warnings
 
-from causing import analyze
+from causing import utils, estimate
 from causing.examples import models
 from causing.utils import print_output, round_sig_recursive
-from causing.graph import create_graphs, sym_to_str
+from causing.graph import create_graphs, create_json_graphs, sym_to_str
+from causing.indiv import create_indiv
 
 # Our examples should run without any warnings, so let's treat them as errors.
 warnings.filterwarnings("error")
@@ -23,26 +24,32 @@ except AttributeError:
     print(f'Unkown model function "{model_name}".')
     exit(1)
 
+# Do all calculations
 model_raw_dat = model_function()
-analyze_dat = analyze(model_raw_dat)
-graphs = analyze_dat["graph_dat"]
+model_dat = utils.create_model(model_raw_dat)
+indiv_dat = create_indiv(model_dat)
+estimate_dat = estimate.estimate_models(model_dat)
+graphs = create_json_graphs(model_dat, estimate_dat, indiv_dat)
 # Round to 6 significant figures to make results stable even with minor floating point inaccuracies
 graphs = round_sig_recursive(graphs, sig=6)
 
+# Print text log
 output_dir = Path("output") / model_name
 output_dir.mkdir(parents=True, exist_ok=True)
 print_output(
-    analyze_dat["model_dat"],
-    analyze_dat["estimate_dat"],
-    analyze_dat["indiv_dat"],
+    model_dat,
+    estimate_dat,
+    indiv_dat,
     output_dir,
 )
+
+# Print json output
 with open(output_dir / "graphs.json", "w") as f:
     json.dump(graphs, f, sort_keys=True, indent=4)
 
-graphs["xnodes"] = [str(var) for var in analyze_dat["model_dat"]["xvars"]]
-graphs["ynodes"] = [str(var) for var in analyze_dat["model_dat"]["yvars"]]
+# Draw graphs
+graphs["xnodes"] = [str(var) for var in model_dat["xvars"]]
+graphs["ynodes"] = [str(var) for var in model_dat["yvars"]]
 graphs["is_all_graph"] = True
 graphs["final_var_is_rat_var"] = False
-
 create_graphs(graphs, output_dir, {})

--- a/causing/examples/__main__.py
+++ b/causing/examples/__main__.py
@@ -24,10 +24,23 @@ except AttributeError:
     print(f'Unkown model function "{model_name}".')
     exit(1)
 
+show_nr_indiv = 3
+
 # Do all calculations
 model_raw_dat, estimate_input = model_function()
 model_dat = utils.create_model(model_raw_dat)
-indiv_dat = create_indiv(model_dat)
+m = model_dat["m"]
+xdat = model_dat["xdat"]
+xmean = model_dat["xdat"].mean(axis=1)
+mean_theo = m.theo(xmean)
+indiv_theos = utils.make_individual_theos(
+    m,
+    model_dat["xdat"],
+    model_dat["show_nr_indiv"],
+)
+indiv_dat = create_indiv(m, xdat, indiv_theos, show_nr_indiv)
+model_dat.update(mean_theo)
+model_dat.update(indiv_theos)
 estimate_dat = estimate.estimate_models(model_dat, estimate_input)
 graphs = create_json_graphs(model_dat, estimate_dat, indiv_dat)
 # Round to 6 significant figures to make results stable even with minor floating point inaccuracies

--- a/causing/examples/__main__.py
+++ b/causing/examples/__main__.py
@@ -25,10 +25,10 @@ except AttributeError:
     exit(1)
 
 # Do all calculations
-model_raw_dat = model_function()
+model_raw_dat, estimate_input = model_function()
 model_dat = utils.create_model(model_raw_dat)
 indiv_dat = create_indiv(model_dat)
-estimate_dat = estimate.estimate_models(model_dat)
+estimate_dat = estimate.estimate_models(model_dat, estimate_input)
 graphs = create_json_graphs(model_dat, estimate_dat, indiv_dat)
 # Round to 6 significant figures to make results stable even with minor floating point inaccuracies
 graphs = round_sig_recursive(graphs, sig=6)
@@ -39,6 +39,7 @@ output_dir.mkdir(parents=True, exist_ok=True)
 print_output(
     model_dat,
     estimate_dat,
+    estimate_input,
     indiv_dat,
     output_dir,
 )

--- a/causing/examples/models.py
+++ b/causing/examples/models.py
@@ -11,29 +11,19 @@ def example():
     """model example"""
 
     X1, X2, Y1, Y2, Y3 = symbols(["X1", "X2", "Y1", "Y2", "Y3"])
-    equations = (
+    equations = (  # equations in topological order (Y1, Y2, ...)
         X1,
         X2 + 2 * Y1 ** 2,
         Y1 + Y2,
     )
-
-    model_dat = {
-        "equations": equations,  # equations in topological order
-        "xvars": [X1, X2],  # exogenous variables in desired order
-        "yvars": [Y1, Y2, Y3],  # endogenous variables in topological order
-        "ymvars": [Y3],  # manifest endogenous variables
-        "final_var": Y3,  # final variable of interest, for mediation analysis
-        "show_nr_indiv": 3,  # show first individual effects
-    }
-
-    # simulate data
     m = Model(
-        model_dat["xvars"],
-        model_dat["yvars"],
-        model_dat["ymvars"],
+        xvars=[X1, X2],  # exogenous variables in desired order
+        yvars=[Y1, Y2, Y3],  # endogenous variables in topological order
+        ymvars=[Y3],  # manifest endogenous variables
         equations=equations,
-        final_var=model_dat["final_var"],
+        final_var=Y3,  # final variable of interest, for mediation analysis
     )
+
     xdat, ymdat = simulate(
         m,
         SimulationParams(
@@ -44,7 +34,6 @@ def example():
             tau=200,  # nr. of simulated observations
         ),
     )
-    model_dat["xdat"] = xdat  # exogenous data
 
     estimate_input = dict(
         ymdat=ymdat,
@@ -53,37 +42,22 @@ def example():
         dof=None,  # effective degrees of freedom, corresponding to alpha
     )
 
-    return model_dat, estimate_input
+    return m, xdat, ymdat, estimate_input
 
 
 def example2():
     """model example 2, no regularization required, no latent variables"""
 
-    X1, Y1 = symbols(
-        [
-            "X1",
-            "Y1",
-        ]
-    )
+    X1, Y1 = symbols(["X1", "Y1"])
     equations = (X1,)
-
-    model_dat = {
-        "equations": equations,
-        "xvars": [X1],
-        "yvars": [Y1],
-        "ymvars": [Y1],
-        "final_var": Y1,
-        "show_nr_indiv": 3,
-    }
-
-    # simulate data
     m = Model(
-        model_dat["xvars"],
-        model_dat["yvars"],
-        model_dat["ymvars"],
         equations=equations,
-        final_var=model_dat["final_var"],
+        xvars=[X1],
+        yvars=[Y1],
+        ymvars=[Y1],
+        final_var=Y1,
     )
+
     xdat, ymdat = simulate(
         m,
         SimulationParams(
@@ -94,7 +68,6 @@ def example2():
             tau=200,
         ),
     )
-    model_dat["xdat"] = xdat
 
     estimate_input = dict(
         ymdat=ymdat,
@@ -102,7 +75,8 @@ def example2():
         alpha=None,
         dof=None,
     )
-    return model_dat, estimate_input
+
+    return m, xdat, ymdat, estimate_input
 
 
 def example3():
@@ -119,24 +93,14 @@ def example3():
         -X1,
         Y1 + Y2,
     )
-
-    model_dat = {
-        "equations": equations,
-        "xvars": [X1],
-        "yvars": [Y1, Y2, Y3],
-        "ymvars": [Y3],
-        "final_var": Y3,
-        "show_nr_indiv": 3,
-    }
-
-    # simulate data
     m = Model(
-        model_dat["xvars"],
-        model_dat["yvars"],
-        model_dat["ymvars"],
         equations=equations,
-        final_var=model_dat["final_var"],
+        xvars=[X1],
+        yvars=[Y1, Y2, Y3],
+        ymvars=[Y3],
+        final_var=Y3,
     )
+
     xdat, ymdat = simulate(
         m,
         SimulationParams(
@@ -147,7 +111,6 @@ def example3():
             tau=200,
         ),
     )
-    model_dat["xdat"] = xdat
 
     estimate_input = dict(
         ymdat=ymdat,
@@ -156,7 +119,7 @@ def example3():
         dof=None,
     )
 
-    return model_dat, estimate_input
+    return m, xdat, ymdat, estimate_input
 
 
 def education():
@@ -223,15 +186,13 @@ def education():
         # WAGE
         7 + 1 * (EDUC - 12) + 0.5 * POTEXPER + 1 * ABILITY,
     )
-
-    model_dat = {
-        "equations": equations,
-        "xvars": [FATHERED, MOTHERED, SIBLINGS, BRKNHOME, ABILITY, AGE],
-        "yvars": [EDUC, POTEXPER, WAGE],
-        "ymvars": [EDUC, POTEXPER, WAGE],
-        "final_var": WAGE,
-        "show_nr_indiv": 3,
-    }
+    m = Model(
+        equations=equations,
+        xvars=[FATHERED, MOTHERED, SIBLINGS, BRKNHOME, ABILITY, AGE],
+        yvars=[EDUC, POTEXPER, WAGE],
+        ymvars=[EDUC, POTEXPER, WAGE],
+        final_var=WAGE,
+    )
 
     # load and transform data
     from numpy import array, concatenate, exp, loadtxt
@@ -246,7 +207,6 @@ def education():
     ymdat = xymdat[[1, 3, 2]]
     ymdat[2, :] = exp(ymdat[2, :])  # wage instead of log wage
     xdat = concatenate((xdat, age))
-    model_dat["xdat"] = xdat
 
     estimate_input = dict(
         ymdat=ymdat,
@@ -255,4 +215,4 @@ def education():
         dof=0.068187,
     )
 
-    return model_dat, estimate_input
+    return m, xdat, ymdat, estimate_input

--- a/causing/examples/models.py
+++ b/causing/examples/models.py
@@ -24,9 +24,6 @@ def example():
         "ymvars": [Y3],  # manifest endogenous variables
         "final_var": Y3,  # final variable of interest, for mediation analysis
         "show_nr_indiv": 3,  # show first individual effects
-        "estimate_bias": True,  # estimate equation biases, for model validation
-        "alpha": None,  # regularization parameter, is estimated if None
-        "dof": None,  # effective degrees of freedom, corresponding to alpha
     }
 
     # simulate data
@@ -47,25 +44,16 @@ def example():
             tau=200,  # nr. of simulated observations
         ),
     )
-
-    # save data
-    # =============================================================================
-    #     from numpy import savetxt
-    #     savetxt("data/xdat.csv", xdat, delimiter=",")
-    #     savetxt("data/ymdat.csv", ymdat, delimiter=",")
-    # =============================================================================
-
-    # load data
-    # =============================================================================
-    #     from numpy import loadtxt
-    #     xdat = loadtxt("data/xdat.csv", delimiter=",").reshape(len(model_dat["xvars"]), -1)
-    #     ymdat = loadtxt("data/ymdat.csv", delimiter=",").reshape(len(model_dat["ymvars"]), -1)
-    # =============================================================================
-
     model_dat["xdat"] = xdat  # exogenous data
-    model_dat["ymdat"] = ymdat  # manifest endogenous data
 
-    return model_dat
+    estimate_input = dict(
+        ymdat=ymdat,
+        estimate_bias=True,  # estimate equation biases, for model validation
+        alpha=None,  # regularization parameter, is estimated if None
+        dof=None,  # effective degrees of freedom, corresponding to alpha
+    )
+
+    return model_dat, estimate_input
 
 
 def example2():
@@ -86,9 +74,6 @@ def example2():
         "ymvars": [Y1],
         "final_var": Y1,
         "show_nr_indiv": 3,
-        "estimate_bias": True,
-        "alpha": None,
-        "dof": None,
     }
 
     # simulate data
@@ -109,11 +94,15 @@ def example2():
             tau=200,
         ),
     )
-
     model_dat["xdat"] = xdat
-    model_dat["ymdat"] = ymdat
 
-    return model_dat
+    estimate_input = dict(
+        ymdat=ymdat,
+        estimate_bias=True,
+        alpha=None,
+        dof=None,
+    )
+    return model_dat, estimate_input
 
 
 def example3():
@@ -138,9 +127,6 @@ def example3():
         "ymvars": [Y3],
         "final_var": Y3,
         "show_nr_indiv": 3,
-        "estimate_bias": True,
-        "alpha": None,
-        "dof": None,
     }
 
     # simulate data
@@ -161,11 +147,16 @@ def example3():
             tau=200,
         ),
     )
-
     model_dat["xdat"] = xdat
-    model_dat["ymdat"] = ymdat
 
-    return model_dat
+    estimate_input = dict(
+        ymdat=ymdat,
+        estimate_bias=True,
+        alpha=None,
+        dof=None,
+    )
+
+    return model_dat, estimate_input
 
 
 def education():
@@ -240,10 +231,6 @@ def education():
         "ymvars": [EDUC, POTEXPER, WAGE],
         "final_var": WAGE,
         "show_nr_indiv": 3,
-        "estimate_bias": True,
-        "alpha": 2.637086,
-        "dof": 0.068187,
-        # "dir_path": "output/",
     }
 
     # load and transform data
@@ -259,8 +246,13 @@ def education():
     ymdat = xymdat[[1, 3, 2]]
     ymdat[2, :] = exp(ymdat[2, :])  # wage instead of log wage
     xdat = concatenate((xdat, age))
-
     model_dat["xdat"] = xdat
-    model_dat["ymdat"] = ymdat
 
-    return model_dat
+    estimate_input = dict(
+        ymdat=ymdat,
+        estimate_bias=True,
+        alpha=2.637086,
+        dof=0.068187,
+    )
+
+    return model_dat, estimate_input

--- a/causing/indiv.py
+++ b/causing/indiv.py
@@ -37,12 +37,10 @@ def compute_delta_mat(xy_dim, m, xdat):
     return dxy_mat, mat_based
 
 
-def create_indiv(model_dat):
+def create_indiv(m, xdat, indiv_theos, show_nr_indiv):
     """create indiv analysis data for mediation indiv graph values,
     using individual total effects and mediation effects"""
 
-    m = model_dat["m"]
-    xdat = model_dat["xdat"]
     tau = xdat.shape[1]
 
     # compute indiv matrices
@@ -50,8 +48,8 @@ def create_indiv(model_dat):
     dy_mat, yhat_based = compute_delta_mat("y", m, xdat)
 
     # compute direct, total and mediation indivs
-    exj_indivs = zeros((model_dat["mdim"], tau))
-    eyj_indivs = zeros((model_dat["ndim"], tau))
+    exj_indivs = zeros((m.mdim, tau))
+    eyj_indivs = zeros((m.ndim, tau))
     mx_indivs = []  # tau times (ndim, mdim)
     my_indivs = []  # tau times (mdim, mdim)
     ex_indivs = []  # tau times (ndim, mdim)
@@ -59,19 +57,23 @@ def create_indiv(model_dat):
     eyx_indivs = []  # tau times (ndim, mdim)
     eyy_indivs = []  # tau times (mdim, mdim)
     print()
-    for obs in range(min(tau, model_dat["show_nr_indiv"])):
+    for obs in range(min(tau, show_nr_indiv)):
         print("Analyze individual {:5}".format(obs))
         # compute indivs row wise, using individual effects, using braodcasting for multiplication
-        exj_indivs[:, obs] = model_dat["exj_theos"][obs] * dx_mat[:, obs].T  # (mdim)
-        eyj_indivs[:, obs] = model_dat["eyj_theos"][obs] * dy_mat[:, obs].T  # (ndim)
+        exj_indivs[:, obs] = indiv_theos["exj_theos"][obs] * dx_mat[:, obs].T  # (mdim)
+        eyj_indivs[:, obs] = indiv_theos["eyj_theos"][obs] * dy_mat[:, obs].T  # (ndim)
         # compute mediation indivs coulumn wise, using individual eyx_theo, eyy_theos,
         # note: when multiplying a large indiv to a derivative, linear approx. errors can occur
-        mx_indivs.append(model_dat["mx_theos"][obs] * dx_mat[:, obs])  # (ndim, mdim)
-        my_indivs.append(model_dat["my_theos"][obs] * dy_mat[:, obs])  # (mdim, mdim)
-        ex_indivs.append(model_dat["ex_theos"][obs] * dx_mat[:, obs])  # (ndim, mdim)
-        ey_indivs.append(model_dat["ey_theos"][obs] * dy_mat[:, obs])  # (mdim, mdim)
-        eyx_indivs.append(model_dat["eyx_theos"][obs] * dx_mat[:, obs])  # (ndim, mdim)
-        eyy_indivs.append(model_dat["eyy_theos"][obs] * dy_mat[:, obs])  # (mdim, mdim)
+        mx_indivs.append(indiv_theos["mx_theos"][obs] * dx_mat[:, obs])  # (ndim, mdim)
+        my_indivs.append(indiv_theos["my_theos"][obs] * dy_mat[:, obs])  # (mdim, mdim)
+        ex_indivs.append(indiv_theos["ex_theos"][obs] * dx_mat[:, obs])  # (ndim, mdim)
+        ey_indivs.append(indiv_theos["ey_theos"][obs] * dy_mat[:, obs])  # (mdim, mdim)
+        eyx_indivs.append(
+            indiv_theos["eyx_theos"][obs] * dx_mat[:, obs]
+        )  # (ndim, mdim)
+        eyy_indivs.append(
+            indiv_theos["eyy_theos"][obs] * dy_mat[:, obs]
+        )  # (mdim, mdim)
 
     indiv_dat = {
         "dx_mat": dx_mat,

--- a/causing/utils.py
+++ b/causing/utils.py
@@ -131,25 +131,11 @@ def create_model(model_dat):
     }
     model_dat.update(setup_dat)
 
-    # theoretical total effects at xmean and corresponding consistent ydet,
-    # using closed form algebraic formula from sympy direct effects
-    #   instead of automatic differentiation of model
-    xmean = model_dat["xdat"].mean(axis=1)
-    model_dat.update(m.theo(xmean))
-
-    model_dat.update(
-        make_individual_theos(
-            m,
-            model_dat["xdat"],
-            tau,
-            model_dat["show_nr_indiv"],
-        )
-    )
-
     return model_dat
 
 
-def make_individual_theos(m, xdat, tau, show_nr_indiv) -> dict:
+def make_individual_theos(m, xdat, show_nr_indiv) -> dict:
+    tau = xdat.shape[1]
     all_theos = defaultdict(list)
     for obs in range(min(tau, show_nr_indiv)):
         xval = xdat[:, obs]

--- a/causing/utils.py
+++ b/causing/utils.py
@@ -84,56 +84,6 @@ def replace_heaviside(mxy, xvars, xval):
     return mxy.astype(np.float64)
 
 
-def create_model(model_dat):
-    """specify model and compute effects"""
-
-    from causing.model import Model
-
-    m = Model(
-        model_dat["xvars"],
-        model_dat["yvars"],
-        model_dat["ymvars"],
-        model_dat["equations"],
-        model_dat["final_var"],
-    )
-
-    # dimensions
-    pdim = len(model_dat["ymvars"])
-    tau = model_dat["xdat"].shape[1]
-
-    # model summary
-    print("Causing starting")
-    print(
-        "\nModel with {} endogenous and {} exogenous variables, "
-        "{} direct effects and {} observations.".format(m.ndim, m.mdim, m.qdim, tau)
-    )
-
-    setup_dat = {
-        # from Model class
-        "m": m,
-        "ndim": m.ndim,
-        "mdim": m.mdim,
-        "pdim": pdim,
-        "qxdim": m.qxdim,
-        "qydim": m.qydim,
-        "qdim": m.qdim,
-        "idx": m.idx,
-        "idy": m.idy,
-        "edx": m.edx,
-        "edy": m.edy,
-        "fdx": m.fdx,
-        "fdy": m.fdy,
-        "model": m.compute,
-        "mx_lam": m.m_pair[0],
-        "my_lam": m.m_pair[1],
-        # other
-        "tau": tau,
-    }
-    model_dat.update(setup_dat)
-
-    return model_dat
-
-
 def make_individual_theos(m, xdat, show_nr_indiv) -> dict:
     tau = xdat.shape[1]
     all_theos = defaultdict(list)

--- a/causing/utils.py
+++ b/causing/utils.py
@@ -101,14 +101,6 @@ def create_model(model_dat):
     pdim = len(model_dat["ymvars"])
     tau = model_dat["xdat"].shape[1]
 
-    # check
-    if model_dat["ymdat"].shape[0] != pdim:
-        raise ValueError(
-            "Number of ymvars {} and ymdat {} not identical.".format(
-                model_dat["ymdat"].shape[0], pdim
-            )
-        )
-
     # model summary
     print("Causing starting")
     print(
@@ -406,7 +398,7 @@ def digital(mat):
     return mat_digital
 
 
-def print_output(model_dat, estimate_dat, indiv_dat, output_dir):
+def print_output(model_dat, estimate_dat, estimate_input, indiv_dat, output_dir):
     """print theoretical and estimated values to output file"""
 
     m = model_dat["m"]
@@ -422,7 +414,7 @@ def print_output(model_dat, estimate_dat, indiv_dat, output_dir):
     # xyvars = concatenate((model_dat["xvars"], model_dat["yvars"]), axis=0)
 
     # compute dataframe strings for printing
-    if model_dat["estimate_bias"]:
+    if estimate_input["estimate_bias"]:
         biases = concatenate(
             (
                 estimate_dat["biases"].reshape(1, -1),
@@ -479,9 +471,9 @@ def print_output(model_dat, estimate_dat, indiv_dat, output_dir):
     ).to_string()
     ydat_stats = vstack(
         (
-            model_dat["ymdat"].mean(axis=1).reshape(1, -1),
-            median(model_dat["ymdat"], axis=1).reshape(1, -1),
-            std(model_dat["ymdat"], axis=1).reshape(1, -1),
+            estimate_input["ymdat"].mean(axis=1).reshape(1, -1),
+            median(estimate_input["ymdat"], axis=1).reshape(1, -1),
+            std(estimate_input["ymdat"], axis=1).reshape(1, -1),
             ones(model_dat["pdim"]).reshape(1, -1),
         )
     )
@@ -524,10 +516,14 @@ def print_output(model_dat, estimate_dat, indiv_dat, output_dir):
 
     # alpha
     print()
-    print("alpha: {:10f}, dof: {:10f}".format(model_dat["alpha"], model_dat["dof"]))
+    print(
+        "alpha: {:10f}, dof: {:10f}".format(
+            estimate_input["alpha"], estimate_input["dof"]
+        )
+    )
 
     # biases
-    if model_dat["estimate_bias"]:
+    if estimate_input["estimate_bias"]:
         print()
         print("biases:")
         print(biases_dfstr)


### PR DESCRIPTION
One more step towards eliminating `model_dat`. Since the `analyze` function's signature was heavily dependent on `model_dat`, it has been removed although it was the obvious external API. I will provide an alternative after additional cleanups.