### PR TITLE
Remove model dat from everywhere but estimation

### DIFF
--- a/causing/estimate.py
+++ b/causing/estimate.py
@@ -523,8 +523,36 @@ def estimate_biases(model_dat, ymdat):
     return biases, biases_std
 
 
-def estimate_models(model_dat, estimate_input):
+def estimate_models(m, xdat, mean_theo, estimate_input):
     """estimation of modification indicators of level model"""
+
+    model_dat = {  # TODO: completely remove model_dat
+        # from Model class
+        "m": m,
+        "ndim": m.ndim,
+        "mdim": m.mdim,
+        "pdim": len(m.ymvars),
+        "qxdim": m.qxdim,
+        "qydim": m.qydim,
+        "qdim": m.qdim,
+        "idx": m.idx,
+        "idy": m.idy,
+        "edx": m.edx,
+        "edy": m.edy,
+        "fdx": m.fdx,
+        "fdy": m.fdy,
+        "model": m.compute,
+        "mx_lam": m.m_pair[0],
+        "my_lam": m.m_pair[1],
+        "xvars": m.xvars,
+        "yvars": m.yvars,
+        "final_var": m.final_var,
+        "ymvars": m.ymvars,
+        # other
+        "xdat": xdat,
+        "tau": xdat.shape[1],
+    }
+    model_dat.update(mean_theo)
 
     # check
     if estimate_input["ymdat"].shape[0] != model_dat["pdim"]:

--- a/causing/examples/__main__.py
+++ b/causing/examples/__main__.py
@@ -56,12 +56,11 @@ model_dat = {  # TODO: completely remove model_dat
     # other
     "xdat": xdat,
     "tau": xdat.shape[1],
-    "show_nr_indiv": show_nr_indiv,
 }
 model_dat.update(mean_theo)
 model_dat.update(indiv_theos)
 estimate_dat = estimate.estimate_models(model_dat, estimate_input)
-graphs = create_json_graphs(model_dat, estimate_dat, indiv_dat)
+graphs = create_json_graphs(model_dat, estimate_dat, indiv_dat, show_nr_indiv)
 # Round to 6 significant figures to make results stable even with minor floating point inaccuracies
 graphs = round_sig_recursive(graphs, sig=6)
 
@@ -85,4 +84,4 @@ graphs["xnodes"] = [str(var) for var in model_dat["xvars"]]
 graphs["ynodes"] = [str(var) for var in model_dat["yvars"]]
 graphs["is_all_graph"] = True
 graphs["final_var_is_rat_var"] = False
-create_graphs(graphs, output_dir, {})
+create_graphs(graphs, output_dir, {}, show_nr_indiv)

--- a/causing/examples/__main__.py
+++ b/causing/examples/__main__.py
@@ -60,7 +60,7 @@ model_dat = {  # TODO: completely remove model_dat
 model_dat.update(mean_theo)
 model_dat.update(indiv_theos)
 estimate_dat = estimate.estimate_models(model_dat, estimate_input)
-graphs = create_json_graphs(model_dat, estimate_dat, indiv_dat, show_nr_indiv)
+graphs = create_json_graphs(m, xdat, estimate_dat, indiv_dat, mean_theo, show_nr_indiv)
 # Round to 6 significant figures to make results stable even with minor floating point inaccuracies
 graphs = round_sig_recursive(graphs, sig=6)
 
@@ -82,8 +82,8 @@ with open(output_dir / "graphs.json", "w") as f:
     json.dump(graphs, f, sort_keys=True, indent=4)
 
 # Draw graphs
-graphs["xnodes"] = [str(var) for var in model_dat["xvars"]]
-graphs["ynodes"] = [str(var) for var in model_dat["yvars"]]
+graphs["xnodes"] = [str(var) for var in m.xvars]
+graphs["ynodes"] = [str(var) for var in m.yvars]
 graphs["is_all_graph"] = True
 graphs["final_var_is_rat_var"] = False
 create_graphs(graphs, output_dir, {}, show_nr_indiv)

--- a/causing/examples/__main__.py
+++ b/causing/examples/__main__.py
@@ -31,35 +31,7 @@ m, xdat, ymdat, estimate_input = model_function()
 mean_theo = m.theo(xdat.mean(axis=1))
 indiv_theos = utils.make_individual_theos(m, xdat, show_nr_indiv)
 indiv_dat = create_indiv(m, xdat, indiv_theos, show_nr_indiv)
-model_dat = {  # TODO: completely remove model_dat
-    # from Model class
-    "m": m,
-    "ndim": m.ndim,
-    "mdim": m.mdim,
-    "pdim": len(m.ymvars),
-    "qxdim": m.qxdim,
-    "qydim": m.qydim,
-    "qdim": m.qdim,
-    "idx": m.idx,
-    "idy": m.idy,
-    "edx": m.edx,
-    "edy": m.edy,
-    "fdx": m.fdx,
-    "fdy": m.fdy,
-    "model": m.compute,
-    "mx_lam": m.m_pair[0],
-    "my_lam": m.m_pair[1],
-    "xvars": m.xvars,
-    "yvars": m.yvars,
-    "final_var": m.final_var,
-    "ymvars": m.ymvars,
-    # other
-    "xdat": xdat,
-    "tau": xdat.shape[1],
-}
-model_dat.update(mean_theo)
-model_dat.update(indiv_theos)
-estimate_dat = estimate.estimate_models(model_dat, estimate_input)
+estimate_dat = estimate.estimate_models(m, xdat, mean_theo, estimate_input)
 graphs = create_json_graphs(m, xdat, estimate_dat, indiv_dat, mean_theo, show_nr_indiv)
 # Round to 6 significant figures to make results stable even with minor floating point inaccuracies
 graphs = round_sig_recursive(graphs, sig=6)

--- a/causing/examples/__main__.py
+++ b/causing/examples/__main__.py
@@ -68,10 +68,12 @@ graphs = round_sig_recursive(graphs, sig=6)
 output_dir = Path("output") / model_name
 output_dir.mkdir(parents=True, exist_ok=True)
 print_output(
-    model_dat,
+    m,
+    xdat,
     estimate_dat,
     estimate_input,
     indiv_dat,
+    mean_theo,
     output_dir,
 )
 

--- a/causing/examples/__main__.py
+++ b/causing/examples/__main__.py
@@ -29,9 +29,8 @@ show_nr_indiv = 3
 # Do all calculations
 m, xdat, ymdat, estimate_input = model_function()
 mean_theo = m.theo(xdat.mean(axis=1))
-indiv_theos = utils.make_individual_theos(m, xdat, show_nr_indiv)
-indiv_dat = create_indiv(m, xdat, indiv_theos, show_nr_indiv)
 estimate_dat = estimate.estimate_models(m, xdat, mean_theo, estimate_input)
+indiv_dat = create_indiv(m, xdat, show_nr_indiv)
 graphs = create_json_graphs(m, xdat, estimate_dat, indiv_dat, mean_theo, show_nr_indiv)
 # Round to 6 significant figures to make results stable even with minor floating point inaccuracies
 graphs = round_sig_recursive(graphs, sig=6)

--- a/causing/graph.py
+++ b/causing/graph.py
@@ -226,7 +226,7 @@ def create_and_save_graph(
     return graph_svg
 
 
-def create_graphs(graph_json, output_dir, node_name):
+def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
     """creates direct, total and mediation graph,
     for theoretical model and estimated model"""
 
@@ -235,7 +235,6 @@ def create_graphs(graph_json, output_dir, node_name):
     ynodes = symbols(graph_json["ynodes"])
     idx = numpy_arr(graph_json["idx"])
     idy = numpy_arr(graph_json["idy"])
-    show_nr_indiv = graph_json["show_nr_indiv"]
     base_var = graph_json["base_var"]
     final_var_is_rat_var = graph_json["final_var_is_rat_var"]
 
@@ -576,11 +575,10 @@ def sym_to_str(sym_list):
     return ", ".join(str(i) for i in sym_list)
 
 
-def create_json_graphs(model_dat, estimate_dat, indiv_dat):
+def create_json_graphs(model_dat, estimate_dat, indiv_dat, show_nr_indiv):
     tau = model_dat["xdat"].shape[1]
     model_json = {
         "table_company": model_dat.get("table_company", None),
-        "show_nr_indiv": min(tau, model_dat["show_nr_indiv"]),
         "idx": model_dat["idx"].tolist(),
         "idy": model_dat["idy"].tolist(),
         # AME_json

--- a/causing/graph.py
+++ b/causing/graph.py
@@ -89,7 +89,6 @@ def dot(
     # color params
     specific_color_str,
     # other
-    base_var,
     show_in_percent: bool,
     node_name: Dict[str, str],
 ) -> str:
@@ -132,10 +131,7 @@ def dot(
         else:
             nodeff_str = ""
             col_str = ""
-        if base_var:  # If full_name # yyy
-            xnode_show = node_name.get(str(xnode), str(xnode))
-        else:
-            xnode_show = xnode
+        xnode_show = node_name.get(str(xnode), str(xnode))
         dot_str += '         "{}"[label = "{}\\n{}"{}];\n'.format(
             xnode, xnode_show, nodeff_str, col_str
         )
@@ -164,7 +160,6 @@ def create_and_save_graph(
     color,
     dir_path,
     filename,
-    base_var,
     final_var_is_rat_var,
     node_name,
     colortrans=None,
@@ -203,7 +198,6 @@ def create_and_save_graph(
         x_weights,
         x_nodeff,
         specific_color_str,
-        base_var,
         show_in_percent,
         node_name,
     )
@@ -213,7 +207,6 @@ def create_and_save_graph(
         y_weights,
         y_nodeff,
         specific_color_str,
-        base_var,
         show_in_percent,
         node_name,
     )
@@ -235,7 +228,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
     ynodes = symbols(graph_json["ynodes"])
     idx = numpy_arr(graph_json["idx"])
     idy = numpy_arr(graph_json["idy"])
-    base_var = graph_json["base_var"]
     final_var_is_rat_var = graph_json["final_var_is_rat_var"]
 
     print("\nAverage and estimated graphs")
@@ -249,7 +241,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
         False,
         dir_path,
         "ADE",
-        base_var,
         final_var_is_rat_var,
         node_name,
     )
@@ -271,7 +262,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
         False,
         dir_path,
         "AME",
-        base_var,
         final_var_is_rat_var,
         node_name,
     )
@@ -292,7 +282,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
             False,
             dir_path,
             "EDE",
-            base_var,
             final_var_is_rat_var,
             node_name,
         )
@@ -312,7 +301,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
             2,
             dir_path,
             "ED0",
-            base_var,
             final_var_is_rat_var,
             node_name,
             lambda x: abs(x),
@@ -332,7 +320,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
             False,
             dir_path,
             "EME",
-            base_var,
             final_var_is_rat_var,
             node_name,
         )
@@ -352,7 +339,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
             2,
             dir_path,
             "EM0",
-            base_var,
             final_var_is_rat_var,
             node_name,
             lambda x: abs(x),
@@ -370,7 +356,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
             2,
             dir_path,
             "ED1",
-            base_var,
             final_var_is_rat_var,
             node_name,
             lambda x: -abs(x),
@@ -392,7 +377,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
             2,
             dir_path,
             "EM1",
-            base_var,
             final_var_is_rat_var,
             node_name,
             lambda x: -abs(x),
@@ -413,7 +397,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
             False,
             dir_path,
             "ATE",
-            base_var,
             final_var_is_rat_var,
             node_name,
         )
@@ -433,7 +416,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
                 False,
                 dir_path,
                 "ETE",
-                base_var,
                 final_var_is_rat_var,
                 node_name,
             )
@@ -448,7 +430,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
                 2,
                 dir_path,
                 "ET0",
-                base_var,
                 final_var_is_rat_var,
                 node_name,
                 lambda x: abs(x),
@@ -462,7 +443,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
                 2,
                 dir_path,
                 "ET1",
-                base_var,
                 final_var_is_rat_var,
                 node_name,
                 lambda x: -abs(x),
@@ -502,7 +482,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
             True,
             dir_path,
             "IDE" + "_" + str(i),
-            base_var,
             final_var_is_rat_var,
             node_name,
         )
@@ -516,7 +495,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
             True,
             dir_path,
             "IME" + "_" + str(i),
-            base_var,
             final_var_is_rat_var,
             node_name,
         )
@@ -530,7 +508,6 @@ def create_graphs(graph_json, output_dir, node_name, show_nr_indiv):
             True,
             dir_path,
             "ITE" + "_" + str(i),
-            base_var,
             final_var_is_rat_var,
             node_name,
         )
@@ -575,28 +552,27 @@ def sym_to_str(sym_list):
     return ", ".join(str(i) for i in sym_list)
 
 
-def create_json_graphs(model_dat, estimate_dat, indiv_dat, show_nr_indiv):
-    tau = model_dat["xdat"].shape[1]
+def create_json_graphs(m, xdat, estimate_dat, indiv_dat, mean_theo, show_nr_indiv):
+    tau = xdat.shape[1]
     model_json = {
-        "table_company": model_dat.get("table_company", None),
-        "idx": model_dat["idx"].tolist(),
-        "idy": model_dat["idy"].tolist(),
+        "idx": m.idx.tolist(),
+        "idy": m.idy.tolist(),
         # AME_json
-        "eyx_theo": model_dat["eyx_theo"].tolist(),  # nm_array
-        "eyy_theo": model_dat["eyy_theo"].tolist(),  # nm_array
-        "fdx": model_dat["fdx"].tolist(),  # nm_array
-        "fdy": model_dat["fdy"].tolist(),  # nm_array
-        "exj_theo": model_dat["exj_theo"].tolist(),  # nm_array
-        "eyj_theo": model_dat["eyj_theo"].tolist(),  # nm_array
+        "eyx_theo": mean_theo["eyx_theo"].tolist(),  # nm_array
+        "eyy_theo": mean_theo["eyy_theo"].tolist(),  # nm_array
+        "fdx": m.fdx.tolist(),  # nm_array
+        "fdy": m.fdy.tolist(),  # nm_array
+        "exj_theo": mean_theo["exj_theo"].tolist(),  # nm_array
+        "eyj_theo": mean_theo["eyj_theo"].tolist(),  # nm_array
         # ED1_json
-        "mx_theo": model_dat["mx_theo"].tolist(),
-        "my_theo": model_dat["my_theo"].tolist(),
+        "mx_theo": mean_theo["mx_theo"].tolist(),
+        "my_theo": mean_theo["my_theo"].tolist(),
         # EM1_json
         # ATE
-        "ex_theo": model_dat["ex_theo"].tolist(),
-        "ey_theo": model_dat["ey_theo"].tolist(),
-        "edx": model_dat["edx"].tolist(),
-        "edy": model_dat["edy"].tolist(),
+        "ex_theo": mean_theo["ex_theo"].tolist(),
+        "ey_theo": mean_theo["ey_theo"].tolist(),
+        "edx": m.edx.tolist(),
+        "edy": m.edy.tolist(),
         # indiv_dat
         "mx_indivs": [indiv.tolist() for indiv in indiv_dat["mx_indivs"]],
         "my_indivs": [indiv.tolist() for indiv in indiv_dat["my_indivs"]],
@@ -606,7 +582,6 @@ def create_json_graphs(model_dat, estimate_dat, indiv_dat, show_nr_indiv):
         "eyj_indivs": indiv_dat["eyj_indivs"].tolist(),
         "ex_indivs": [indiv.tolist() for indiv in indiv_dat["ex_indivs"]],
         "ey_indivs": [indiv.tolist() for indiv in indiv_dat["ey_indivs"]],
-        "base_var": True if "base_var" in model_dat else False,
     }
 
     if estimate_dat:

--- a/causing/indiv.py
+++ b/causing/indiv.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Create analysis data for individual graph values."""
 
+from collections import defaultdict
+
 from numpy import median, zeros
 
 
@@ -37,11 +39,25 @@ def compute_delta_mat(xy_dim, m, xdat):
     return dxy_mat, mat_based
 
 
-def create_indiv(m, xdat, indiv_theos, show_nr_indiv):
+def make_individual_theos(m, xdat, show_nr_indiv) -> dict:
+    tau = xdat.shape[1]
+    all_theos = defaultdict(list)
+    for obs in range(min(tau, show_nr_indiv)):
+        xval = xdat[:, obs]
+        theo = m.theo(xval)
+
+        for key, val in theo.items():
+            all_theos[key + "s"].append(val)
+
+    return all_theos
+
+
+def create_indiv(m, xdat, show_nr_indiv):
     """create indiv analysis data for mediation indiv graph values,
     using individual total effects and mediation effects"""
 
     tau = xdat.shape[1]
+    indiv_theos = make_individual_theos(m, xdat, show_nr_indiv)
 
     # compute indiv matrices
     dx_mat, xdat_based = compute_delta_mat("x", m, xdat)

--- a/causing/model.py
+++ b/causing/model.py
@@ -49,6 +49,7 @@ class Model:
         )
 
         # more dimensions
+        self.pdim = len(self.ymvars)
         self.qxdim = utils.count_nonzero(self.idx)
         self.qydim = utils.count_nonzero(self.idy)
         self.qdim = self.qxdim + self.qydim

--- a/causing/utils.py
+++ b/causing/utils.py
@@ -5,7 +5,6 @@
 # pylint: disable=E1101 # "torch has nor 'DoubleTensor' menber"
 
 from typing import Tuple, List
-from collections import defaultdict
 from copy import copy, deepcopy
 
 import pydot
@@ -82,19 +81,6 @@ def replace_heaviside(mxy, xvars, xval):
                 mxy[i, j] = mxy[i, j].subs(Heaviside(0), 0)
 
     return mxy.astype(np.float64)
-
-
-def make_individual_theos(m, xdat, show_nr_indiv) -> dict:
-    tau = xdat.shape[1]
-    all_theos = defaultdict(list)
-    for obs in range(min(tau, show_nr_indiv)):
-        xval = xdat[:, obs]
-        theo = m.theo(xval)
-
-        for key, val in theo.items():
-            all_theos[key + "s"].append(val)
-
-    return all_theos
 
 
 def nonzero(el):

--- a/output/education/graphs.json
+++ b/output/education/graphs.json
@@ -1,5 +1,4 @@
 {
-    "base_var": false,
     "edx": [
         [
             1.0,
@@ -162246,6 +162245,5 @@
             0.5,
             NaN
         ]
-    ],
-    "table_company": null
+    ]
 }

--- a/output/education/graphs.json
+++ b/output/education/graphs.json
@@ -162247,6 +162247,5 @@
             NaN
         ]
     ],
-    "show_nr_indiv": 3,
     "table_company": null
 }

--- a/output/example/graphs.json
+++ b/output/example/graphs.json
@@ -1704,6 +1704,5 @@
             NaN
         ]
     ],
-    "show_nr_indiv": 3,
     "table_company": null
 }

--- a/output/example/graphs.json
+++ b/output/example/graphs.json
@@ -1,5 +1,4 @@
 {
-    "base_var": false,
     "edx": [
         [
             1.0,
@@ -1703,6 +1702,5 @@
             1.0,
             NaN
         ]
-    ],
-    "table_company": null
+    ]
 }

--- a/output/example2/graphs.json
+++ b/output/example2/graphs.json
@@ -1,5 +1,4 @@
 {
-    "base_var": false,
     "edx": [
         [
             1.0
@@ -647,6 +646,5 @@
         [
             NaN
         ]
-    ],
-    "table_company": null
+    ]
 }

--- a/output/example2/graphs.json
+++ b/output/example2/graphs.json
@@ -648,6 +648,5 @@
             NaN
         ]
     ],
-    "show_nr_indiv": 3,
     "table_company": null
 }

--- a/output/example3/graphs.json
+++ b/output/example3/graphs.json
@@ -1,5 +1,4 @@
 {
-    "base_var": false,
     "edx": [
         [
             1.0
@@ -1435,6 +1434,5 @@
             1.0,
             NaN
         ]
-    ],
-    "table_company": null
+    ]
 }

--- a/output/example3/graphs.json
+++ b/output/example3/graphs.json
@@ -1436,6 +1436,5 @@
             NaN
         ]
     ],
-    "show_nr_indiv": 3,
     "table_company": null
 }


### PR DESCRIPTION
This looks ugly in the estimation right now, but at least the madness of everything-in-model-dat is now contained within the `estimation.py`.