### PR TITLE
Use CPU-only torch package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         "pandas==1.1.5",
         "scipy==1.5.4",
         "sympy==1.5.1",
-        "torch==1.9.1",
+        "torch@https://download.pytorch.org/whl/cpu/torch-1.9.1%2Bcpu-cp39-cp39-linux_x86_64.whl",
         "pre-commit",
     ],
     python_requires=">=3.9",


### PR DESCRIPTION
Pro:
- Much smaller download (~700MB less)
- Faster CI runs due to smaller download
- All users of Causing

Cons:
- I hardcoded the linux-python3.9 version, since I could not get both
  pip and setuptools to correctly search
  https://download.pytorch.org/whl/cpu/torch_stable.html for the right
  download. Suggestions on how to fix this welcome!