### PR TITLE
Use less strict versioning of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="causing",  # Replace with your own username
-    version="0.1.6",
+    name="causing",
+    version="0.1.7",
     author="Dr. Holger Bartel",
     author_email="holger.bartel@realrate.ai",
     description="Causing: CAUSal INterpretation using Graphs",
@@ -19,13 +19,13 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "numdifftools==0.9.39",
-        "numpy>=1.18.1",
-        "pydot==1.4.1",
-        "pandas==1.1.5",
-        "scipy==1.5.4",
-        "sympy==1.5.1",
-        "torch==1.9.1",
+        "numdifftools~=0.9.39",
+        "numpy~=1.18",
+        "pydot~=1.4",
+        "pandas~=1.3",
+        "scipy~=1.5.4",
+        "sympy~=1.5.1",
+        "torch~=1.9.1",
         "pre-commit",
     ],
     python_requires=">=3.9",


### PR DESCRIPTION
Since Causing is intended to be used as a library, dictating the exact
versions of all Causing-dependencies to the downstream project is not
desirable. To avoid too big changes in versioning, I specified the
versions using the compatible release specifier:
https://www.python.org/dev/peps/pep-0440/#compatible-release

There is no guarantee that all matching versions really are compatible,
but it's better than nothing.

Ideally, we would have a frozen list of specific versions to use in CI
in addition to the loose versions in setup.py, but I didn't add a
mechanism to handle that to avoid the complexity. If we ever change to
more modern tooling like poetry, we'll get that for free.