### PR TITLE
Make pytorch optional

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .
+        pip install .[estimate]
         sudo apt-get install graphviz
     - name: Verify examples output
       run: make verify-output

--- a/causing/__init__.py
+++ b/causing/__init__.py
@@ -4,8 +4,15 @@
 # flake8: noqa
 
 # public Causing API
-from causing.estimate import estimate_models
+from causing.bias import estimate_biases
 from causing.indiv import create_indiv
 from causing.graph import create_json_graphs
 from causing.model import Model
 from causing.simulate import simulate, SimulationParams
+
+try:
+    import torch
+    from causing.estimate import estimate_models
+except:
+    # Running without pytorch is allowed, but estimate_models won't be available
+    pass

--- a/causing/estimate.py
+++ b/causing/estimate.py
@@ -828,31 +828,6 @@ def sse_hess(mx, my, model_dat, alpha):
     return hessian
 
 
-def tvals(eff, std):
-    """compute t-values by element wise division of eff and std matrices"""
-
-    assert eff.shape == std.shape
-
-    if len(eff.shape) == 1:  # vector
-        rows = eff.shape[0]
-        tvalues = np.empty(rows) * np.nan
-        for i in range(rows):
-            if std[i] != 0:
-                tvalues[i] = eff[i] / std[i]
-
-    if len(eff.shape) == 2:  # matrix
-        rows, cols = eff.shape
-        tvalues = zeros((rows, cols))
-        for i in range(rows):
-            for j in range(cols):
-                if std[i, j] != 0:
-                    tvalues[i, j] = eff[i, j] / std[i, j]
-                else:
-                    tvalues[i, j] = np.nan
-
-    return tvalues
-
-
 def compute_mediation_std(ex_hat_std, ey_hat_std, eyx, eyy, yvars, final_var):
     """compute mediation std"""
 

--- a/causing/examples/__main__.py
+++ b/causing/examples/__main__.py
@@ -5,7 +5,7 @@ import logging
 
 import pandas
 
-import causing.bias
+import causing
 from causing import estimate
 from causing.examples import models
 from causing.utils import print_output, print_bias, round_sig_recursive, dump_json
@@ -39,8 +39,8 @@ show_nr_indiv = 3
 # Do all calculations
 m, xdat, ymdat, estimate_input = model_function()
 mean_theo = m.theo(xdat.mean(axis=1))
-estimate_dat = estimate.estimate_models(m, xdat, mean_theo, estimate_input)
-biases, biases_std = causing.bias.estimate_biases(
+estimate_dat = causing.estimate_models(m, xdat, mean_theo, estimate_input)
+biases, biases_std = causing.estimate_biases(
     m, xdat, estimate_input["ymvars"], estimate_input["ymdat"]
 )
 indiv_dat = create_indiv(m, xdat, show_nr_indiv)

--- a/causing/graph.py
+++ b/causing/graph.py
@@ -6,8 +6,32 @@ from itertools import chain
 import numpy as np
 from numpy import allclose, isnan
 from causing import utils
-from causing.estimate import tvals
 from causing.model import Model
+
+
+def tvals(eff, std):
+    """compute t-values by element wise division of eff and std matrices"""
+
+    assert eff.shape == std.shape
+
+    if len(eff.shape) == 1:  # vector
+        rows = eff.shape[0]
+        tvalues = np.empty(rows) * np.nan
+        for i in range(rows):
+            if std[i] != 0:
+                tvalues[i] = eff[i] / std[i]
+
+    if len(eff.shape) == 2:  # matrix
+        rows, cols = eff.shape
+        tvalues = np.zeros((rows, cols))
+        for i in range(rows):
+            for j in range(cols):
+                if std[i, j] != 0:
+                    tvalues[i, j] = eff[i, j] / std[i, j]
+                else:
+                    tvalues[i, j] = np.nan
+
+    return tvalues
 
 
 def color_scheme(value, base):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="causing",
-    version="0.1.7",
+    version="0.2.0",
     author="Dr. Holger Bartel",
     author_email="holger.bartel@realrate.ai",
     description="Causing: CAUSal INterpretation using Graphs",

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,13 @@ setuptools.setup(
         "pandas~=1.3",
         "scipy~=1.5.4",
         "sympy~=1.5.1",
-        "torch~=1.9.1",
         "pre-commit",
     ],
+    extras_require=dict(
+        estimate=[
+            "torch~=1.9.1",
+        ]
+    ),
     python_requires=">=3.9",
     setup_requires=["wheel"],
 )


### PR DESCRIPTION
PyTorch is by far our biggest dependency. Users of causing can skip it as long as they don't require the `estimate_models` command. Installing pytorch will enable that command, and depending on `causing[estimate]` will add the correct pytorch version as a dependency implicitly.