### PR TITLE
Fix svg graph scaling issue.

### DIFF
--- a/causing/graph.py
+++ b/causing/graph.py
@@ -69,8 +69,8 @@ def save_graph(path: Path, graph_dot):
     svg_code = subprocess.check_output(
         [DOT_COMMAND, "-Tsvg"], input=graph_dot, encoding="utf-8"
     )
-    if dot_version()[0] < 3:
-        svg_code = fix_svg_scale(svg_code)
+    # if dot_version()[0] < 3:
+    #     svg_code = fix_svg_scale(svg_code)
     with open(path, "w") as f:
         f.write(svg_code)
 


### PR DESCRIPTION
The following function adjusts the SVG scale, which is no longer necessary with the current version of Graphviz.
In the latest GitHub Actions runner, the Graphviz version used results in cropped SVG graphs when this function is applied.
However, this function might still be useful for other versions of Graphviz, so we are keeping it as a comment for reference.