### PR TITLE
floatingpointerror: set underflow error to ignore

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/setup-python@v2
       with:
           python-version: '3.9'
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}

--- a/causing/model.py
+++ b/causing/model.py
@@ -88,7 +88,7 @@ class Model:
                     #     [eq(*eq_in, *parameters.values()) for eq_in in eq_inputs],
                     #     dtype=np.float64,
                     # )
-                    np.seterr(under='ignore')
+                    np.seterr(under="ignore")
                     computed_yvars = []
                     for eq_in in eq_inputs:
                         computed_yvars.append(eq(*eq_in, *parameters.values()))

--- a/causing/model.py
+++ b/causing/model.py
@@ -88,9 +88,9 @@ class Model:
                     #     [eq(*eq_in, *parameters.values()) for eq_in in eq_inputs],
                     #     dtype=np.float64,
                     # )
+                    np.seterr(under='ignore')
                     computed_yvars = []
                     for eq_in in eq_inputs:
-                        eq_in = [np.float128(value) for value in eq_in]
                         computed_yvars.append(eq(*eq_in, *parameters.values()))
 
                     yhat[i] = np.array(


### PR DESCRIPTION
For now, we will keep @np.errstate(all="raise") as it is and use np.seterr(under='ignore') at the specific computation points, as NumPy is smart enough to handle underflow cases appropriately.