### PR TITLE
Loosen dependency pins for Python 3.13+ support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "numpy~=1.23",
-        "pandas~=1.3",
-        "scipy~=1.9",
-        "sympy~=1.5",
-        "networkx~=2.7",
+        "numpy>=1.23",
+        "pandas>=1.3",
+        "scipy>=1.9",
+        "sympy>=1.5",
+        "networkx>=2.7",
         "pre-commit",  # TODO: move to dev-requirements
     ],
     python_requires=">=3.9",


### PR DESCRIPTION
## Summary

- Changes `~=` (compatible release) pins to `>=` (minimum version) for numpy, pandas, scipy, sympy, and networkx in `setup.py`
- Enables installation on Python 3.13 where the old pinned versions (e.g. numpy 1.23.x) are unavailable

## Test results

All 22 tests pass with the latest versions:
- numpy 2.3.5 (was pinned to ~=1.23)
- pandas 3.0.1 (was pinned to ~=1.3)
- scipy 1.17.0 (was pinned to ~=1.9)
- networkx 3.x (was pinned to ~=2.7)

## Review note for Salistha

Please check whether the **ERSTE project** relies on the current restrictive dependency pins. If ERSTE requires specific versions of numpy/pandas/scipy, we may need to keep tighter constraints or use a separate requirements file for that project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)