### PR TITLE
Relax numpy/pandas/networkx pins to support numpy 2 / pandas 2+ / Python 3.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="causing",
-    version="2.4.6",
+    version="2.5.0",
     author="Dr. Holger Bartel",
     author_email="holger.bartel@realrate.ai",
     description="Causing: CAUSal INterpretation using Graphs",
@@ -19,11 +19,15 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "numpy~=1.23",
-        "pandas~=1.3",
-        "scipy~=1.9",
-        "sympy~=1.5",
-        "networkx~=2.7",
+        # Lower-bound floors only: the previous `~=` upper caps blocked numpy 2 /
+        # pandas 2+ / networkx 3 and made Python 3.14 impossible (no pandas 1.x cp314
+        # wheels). Verified numerically equivalent across the stack jump — see
+        # https://github.com/realrate/RealRate-Private/issues/2098
+        "numpy>=1.23",
+        "pandas>=1.3",
+        "scipy>=1.9",
+        "sympy>=1.5",
+        "networkx>=2.7",
         "pre-commit",  # TODO: move to dev-requirements
     ],
     python_requires=">=3.9",


### PR DESCRIPTION
Closes #101

## What
Replace the `~=` upper-bound caps in `setup.py` with lower-bound floors, and bump version `2.4.6` → `2.5.0`.

```diff
-"numpy~=1.23"      +"numpy>=1.23"
-"pandas~=1.3"      +"pandas>=1.3"
-"scipy~=1.9"       +"scipy>=1.9"
-"sympy~=1.5"       +"sympy>=1.5"
-"networkx~=2.7"    +"networkx>=2.7"
```

## Why
The caps blocked numpy 2 / pandas 2+ / networkx 3 and made **Python 3.14 impossible** (pandas 1.x ships no `cp314` wheels). This was blocking the downstream RealRate-Private uv / Python 3.14 migration (realrate/RealRate-Private#2098) and a batch of Dependabot upgrades there.

## Verification (Python 3.14 + numpy 2.4.6 / pandas 3.0.3 / scipy 1.17.1 / sympy 1.14.0 / networkx 3.6.1)
- **Unit suite:** 24/24 pass (2 pre-existing skips)
- **`make verify-output`:** all 5 example `graphs.json` **byte-identical** to the committed baseline
- **RealRate A/B** (`de_life_insurance` evaluate, old py3.9 stack vs new): **8/8 years (2016–2023) identical within 1e-10**
- **Lint/security:** black, flake8, mypy clean; `pip-audit` on the resolved stack reports no known vulnerabilities

## Note (not a regression)
Under numpy 2, `sympy.lambdify` emits `np.maximum`/`np.minimum` with >2 positional args for `Max`/`Min`; numpy treats the 3rd positional as `out`. Behavior is identical under numpy 1.23 (hence the exact A/B match), so it's pre-existing — flagged in #101 for a separate look.

## Follow-up
Once merged, tag `v2.5.0` and publish to PyPI so RealRate-Private can drop its temporary `[tool.uv] override-dependencies` workaround.